### PR TITLE
Fix LovelaceData.mode AttributeError on HA 2026.2+

### DIFF
--- a/custom_components/logger_manager/frontend/__init__.py
+++ b/custom_components/logger_manager/frontend/__init__.py
@@ -32,13 +32,13 @@ class JSModuleRegistration:
         await self._async_register_path()
 
         # Only attempt automatic resource registration if Lovelace is in storage mode
-        if self.lovelace_data and self.lovelace_data.mode == "storage":
-            _LOGGER.debug("Lovelace mode: %s - will attempt automatic resource registration", self.lovelace_data.mode)
+        if self.lovelace_data and self.lovelace_data.resource_mode == "storage":
+            _LOGGER.debug("Lovelace resource mode: %s - will attempt automatic resource registration", self.lovelace_data.resource_mode)
             await self._async_wait_for_lovelace_resources()
         else:
-            mode = self.lovelace_data.mode if self.lovelace_data else "not available"
+            mode = self.lovelace_data.resource_mode if self.lovelace_data else "not available"
             _LOGGER.info(
-                "Lovelace mode: %s - automatic registration skipped. "
+                "Lovelace resource mode: %s - automatic registration skipped. "
                 "Users will need to manually add the card resource.", mode
             )
 
@@ -108,7 +108,7 @@ class JSModuleRegistration:
             "If you have Logger Manager cards on your dashboards, they will need to be removed manually."
         )
 
-        if not self.lovelace_data or self.lovelace_data.mode != "storage":
+        if not self.lovelace_data or self.lovelace_data.resource_mode != "storage":
             _LOGGER.debug("Lovelace not in storage mode, no resources to unregister")
             return
 


### PR DESCRIPTION
HA 2026.2 renamed LovelaceData.mode to LovelaceData.resource_mode. 

```
2026-02-16 14:25:04.432 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Logger Manager for logger_manager
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/config_entries.py", line 762, in __async_setup_with_context
  result = await component.async_setup_entry(hass, self)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/logger_manager/__init__.py", line 252, in async_setup_entry
  await module_register.async_register()
File "/config/custom_components/logger_manager/frontend/__init__.py", line 35, in async_register
  if self.lovelace_data and self.lovelace_data.mode == "storage":
                            ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'LovelaceData' object has no attribute 'mode'
```

Haven't found a lot of docs about this, but I found a reference here:
https://github.com/thomasloven/lovelace-card-mod

Update all references in frontend registration to use the new attribute.